### PR TITLE
IDs should be shorter

### DIFF
--- a/backend/src/main/kotlin/com/etchedjournal/etched/EtchedConfig.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/EtchedConfig.kt
@@ -4,6 +4,8 @@ import com.etchedjournal.etched.service.AuthService
 import com.etchedjournal.etched.service.OpenIdConnectApi
 import com.etchedjournal.etched.service.impl.AuthServiceImpl
 import com.etchedjournal.etched.service.impl.KeycloakOpenIdConnectApi
+import com.etchedjournal.etched.utils.id.IdGenerator
+import com.etchedjournal.etched.utils.id.IdGeneratorImpl
 import org.keycloak.OAuth2Constants
 import org.keycloak.admin.client.Keycloak
 import org.keycloak.admin.client.KeycloakBuilder
@@ -23,40 +25,37 @@ import javax.servlet.http.HttpServletResponse
 
 @Configuration
 class EtchedConfig {
-    companion object {
-        val log: Logger = LoggerFactory.getLogger(EtchedConfig::class.java)
-    }
 
     @Bean
     fun openIdConnectApi(
-            @Value("\${keycloak.auth-server-url}") authServerUrl: String,
-            @Value("\${keycloak.realm}") realm: String,
-            @Value("\${keycloak.resource}") resource: String,
-            @Value("\${keycloak.credentials.secret}") clientSecret: String
+        @Value("\${keycloak.auth-server-url}") authServerUrl: String,
+        @Value("\${keycloak.realm}") realm: String,
+        @Value("\${keycloak.resource}") resource: String,
+        @Value("\${keycloak.credentials.secret}") clientSecret: String
     ): OpenIdConnectApi {
         return KeycloakOpenIdConnectApi("$authServerUrl/realms/$realm/", resource, clientSecret)
     }
 
     @Bean
     fun keycloak(
-            @Value("\${keycloak.auth-server-url}") authServerUrl: String,
-            @Value("\${keycloak.realm}") realm: String,
-            @Value("\${keycloak.resource}") resource: String,
-            @Value("\${keycloak.credentials.secret}") clientSecret: String
+        @Value("\${keycloak.auth-server-url}") authServerUrl: String,
+        @Value("\${keycloak.realm}") realm: String,
+        @Value("\${keycloak.resource}") resource: String,
+        @Value("\${keycloak.credentials.secret}") clientSecret: String
     ): Keycloak {
         return KeycloakBuilder.builder()
-                .clientId(resource)
-                .clientSecret(clientSecret)
-                .serverUrl(authServerUrl)
-                .realm(realm)
-                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
-                .build()
+            .clientId(resource)
+            .clientSecret(clientSecret)
+            .serverUrl(authServerUrl)
+            .realm(realm)
+            .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+            .build()
     }
 
     @Bean()
     fun etchedRealm(
-            keycloak: Keycloak,
-            @Value("\${keycloak.realm}") realm: String
+        keycloak: Keycloak,
+        @Value("\${keycloak.realm}") realm: String
     ): RealmResource {
         return keycloak.realm(realm)
     }
@@ -64,6 +63,15 @@ class EtchedConfig {
     @Bean
     fun authService(openIdConnectApi: OpenIdConnectApi, etchedRealm: RealmResource): AuthService {
         return AuthServiceImpl(openIdConnectApi, etchedRealm)
+    }
+
+    @Bean
+    fun idGenerator(): IdGenerator {
+        return IdGeneratorImpl.INSTANCE
+    }
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(EtchedConfig::class.java)
     }
 }
 

--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/EntryServiceController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/EntryServiceController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 import javax.validation.Valid
 
 @RequestMapping("/api/v1/entries")
@@ -22,7 +21,7 @@ class EntryServiceController(private val entryService: EntryService) {
      * Returns an Entry with the specified ID.
      */
     @GetMapping("/{entryId}")
-    fun getEntry(@PathVariable entryId: UUID): EntryEntity {
+    fun getEntry(@PathVariable entryId: String): EntryEntity {
         return entryService.getEntry(entryId)
     }
 
@@ -30,7 +29,7 @@ class EntryServiceController(private val entryService: EntryService) {
      * Returns all entries.
      */
     @GetMapping("")
-    fun getEntries(@RequestParam journalId: UUID): List<EntryEntity> {
+    fun getEntries(@RequestParam journalId: String): List<EntryEntity> {
         return entryService.getEntries(journalId)
     }
 
@@ -40,7 +39,7 @@ class EntryServiceController(private val entryService: EntryService) {
     @PostMapping("")
     fun create(
         @RequestBody @Valid entry: EncryptedEntityRequest,
-        @RequestParam journalId: UUID
+        @RequestParam journalId: String
     ): EntryEntity {
         logger.info("Creating an entry for journal {}", journalId)
         val createdEntry = entryService.create(journalId, entry.content)

--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/EtchServiceController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/EtchServiceController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 import javax.validation.Valid
 
 @RequestMapping("/api/v1/etches")
@@ -19,18 +18,18 @@ import javax.validation.Valid
 class EtchServiceController(private val etchService: EtchService) {
 
     @GetMapping("")
-    fun getEtches(@RequestParam entryId: UUID): List<EtchEntity> {
+    fun getEtches(@RequestParam entryId: String): List<EtchEntity> {
         return etchService.getEtches(entryId)
     }
 
     @GetMapping("/{etchId}")
-    fun getEtch(@PathVariable etchId: UUID): EtchEntity {
+    fun getEtch(@PathVariable etchId: String): EtchEntity {
         return etchService.getEtch(etchId)
     }
 
     @PostMapping("")
     fun create(
-        @RequestParam entryId: UUID,
+        @RequestParam entryId: String,
         @RequestBody etches: List<@Valid EncryptedEntityRequest>
     ): List<EtchEntity> {
         logger.info("Creating etches for entry {}", entryId)

--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/JournalServiceController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/JournalServiceController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/journals")
@@ -24,7 +23,7 @@ class JournalServiceController(private val journalService: JournalService) {
     }
 
     @GetMapping("/{journalId}")
-    fun getJournal(@PathVariable journalId: UUID): JournalEntity {
+    fun getJournal(@PathVariable journalId: String): JournalEntity {
         return journalService.getJournal(journalId)
     }
 

--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/KeypairServiceController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/KeypairServiceController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 import javax.validation.Valid
 
 @RestController
@@ -59,7 +58,7 @@ class KeypairServiceController(
     }
 
     @GetMapping("/{keypairId}")
-    fun getKeypair(@PathVariable keypairId: UUID): KeypairEntity {
+    fun getKeypair(@PathVariable keypairId: String): KeypairEntity {
         logger.info("Getting keypair with id {}", keypairId)
         return keypairService.getKeypair(keypairId)
     }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/BaseEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/BaseEntity.kt
@@ -1,0 +1,41 @@
+package com.etchedjournal.etched.models.entity
+
+import com.etchedjournal.etched.models.OwnerType
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.MappedSuperclass
+import javax.persistence.Version
+
+@MappedSuperclass
+abstract class BaseEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "id_generator")
+    @Column(nullable = false, unique = true, updatable = false, insertable = true)
+    @JsonIgnore
+    var _id: Long? = null,
+
+    @Column(unique = true, nullable = false, updatable = false, insertable = true)
+    val id: String,
+
+    /** Represents the created time of the entity */
+    @Column(nullable = false, updatable = false)
+    val timestamp: Instant,
+
+    @Column(nullable = false)
+    val owner: String,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val ownerType: OwnerType,
+
+    @Version
+    @Column(nullable = false)
+    @JsonIgnore
+    var _version: Int? = null
+)

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EncryptedEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EncryptedEntity.kt
@@ -2,38 +2,18 @@ package com.etchedjournal.etched.models.entity
 
 import com.etchedjournal.etched.models.OwnerType
 import java.time.Instant
-import java.util.UUID
 import javax.persistence.Column
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
 abstract class EncryptedEntity(
-    /**
-     * This is only null when creating an entry. When retrieved by the database safe to
-     * assume non-null
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", unique = true, nullable = false, updatable = false)
-    var id: UUID? = null,
+    id: String,
+    timestamp: Instant,
+    owner: String,
+    ownerType: OwnerType,
 
     @Column(nullable = false)
-    val timestamp: Instant = Instant.now(),
-
-    @Column(nullable = false)
-    val content: ByteArray,
-
-    @Column(nullable = false)
-    val owner: String,
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    val ownerType: OwnerType
+    val content: ByteArray
 
     // TODO: Should we store the key id used to encrypt this entity?
     // I think we should
@@ -42,4 +22,10 @@ abstract class EncryptedEntity(
     //    set up a "challenge" were we verify that they are holding the private key by sending a
     //    nonce encrypted by the public key. If they can tell us what the nonce is, they've proven
     //    ownership of the key
+
+) : BaseEntity(
+    id = id,
+    timestamp = timestamp,
+    owner = owner,
+    ownerType = ownerType
 )

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EntryEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EntryEntity.kt
@@ -3,23 +3,29 @@ package com.etchedjournal.etched.models.entity
 import com.etchedjournal.etched.models.OwnerType
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.time.Instant
-import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.Inheritance
 import javax.persistence.InheritanceType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.SequenceGenerator
 import javax.persistence.Table
 
 @Entity
 @Table(name = "entries")
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@SequenceGenerator(
+    name = "id_generator",
+    sequenceName = "entries_id_sequence",
+    initialValue = 1,
+    allocationSize = 1
+)
 class EntryEntity(
-    id: UUID? = null,
-    timestamp: Instant = Instant.now(),
+    id: String,
     content: ByteArray,
     owner: String,
     ownerType: OwnerType,
+    timestamp: Instant,
 
     @ManyToOne
     @JoinColumn(name = "journal_id")
@@ -27,10 +33,10 @@ class EntryEntity(
     val journal: JournalEntity
 ) : EncryptedEntity(
     id = id,
-    timestamp = timestamp,
     content = content,
     owner = owner,
-    ownerType = ownerType
+    ownerType = ownerType,
+    timestamp = timestamp
 ) {
     override fun toString(): String {
         return "EntryEntity(" +

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EtchEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/EtchEntity.kt
@@ -3,17 +3,26 @@ package com.etchedjournal.etched.models.entity
 import com.etchedjournal.etched.models.OwnerType
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.time.Instant
-import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.SequenceGenerator
 import javax.persistence.Table
 
 @Entity
 @Table(name = "etches")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@SequenceGenerator(
+    name = "id_generator",
+    sequenceName = "etches_id_sequence",
+    initialValue = 1,
+    allocationSize = 1
+)
 class EtchEntity(
-    id: UUID? = null,
-    timestamp: Instant = Instant.now(),
+    id: String,
+    timestamp: Instant,
     content: ByteArray,
     owner: String,
     ownerType: OwnerType,

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/JournalEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/JournalEntity.kt
@@ -2,24 +2,33 @@ package com.etchedjournal.etched.models.entity
 
 import com.etchedjournal.etched.models.OwnerType
 import java.time.Instant
-import java.util.UUID
 import javax.persistence.Entity
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
+import javax.persistence.SequenceGenerator
 import javax.persistence.Table
 
 @Entity
 @Table(name = "journals")
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@SequenceGenerator(
+    name = "id_generator",
+    sequenceName = "journals_id_sequence",
+    initialValue = 1,
+    allocationSize = 1
+)
 class JournalEntity(
-    id: UUID? = null,
-    timestamp: Instant = Instant.now(),
+    id: String,
     content: ByteArray,
     owner: String,
-    ownerType: OwnerType
+    ownerType: OwnerType,
+    timestamp: Instant
 ) : EncryptedEntity(
     id = id,
-    timestamp = timestamp,
     content = content,
     owner = owner,
-    ownerType = ownerType
+    ownerType = ownerType,
+    timestamp = timestamp
 ) {
     override fun toString(): String {
         return "JournalEntity(" +

--- a/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/KeypairEntity.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/models/entity/KeypairEntity.kt
@@ -2,67 +2,63 @@ package com.etchedjournal.etched.models.entity
 
 import com.etchedjournal.etched.models.OwnerType
 import java.time.Instant
-import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
+import javax.persistence.SequenceGenerator
 import javax.persistence.Table
 
 @Entity
 @Table(name = "keypairs")
-data class KeypairEntity(
-    /**
-     * This is only null when creating an entry. When retrieved by the database safe to
-     * assume non-null
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", unique = true, nullable = false, updatable = false)
-    var id: UUID? = null,
-
-    @Column(nullable = false)
-    val timestamp: Instant = Instant.now(),
+@SequenceGenerator(
+    name = "id_generator",
+    sequenceName = "key_pairs_id_sequence",
+    initialValue = 1,
+    allocationSize = 1
+)
+class KeypairEntity(
+    id: String,
+    timestamp: Instant,
+    owner: String,
+    ownerType: OwnerType,
 
     @Column(name = "public_key", unique = true, nullable = false)
     val publicKey: ByteArray,
 
     @Column(name = "private_key", unique = true, nullable = false)
-    val privateKey: ByteArray,
+    val privateKey: ByteArray
 
     // TODO: Should we store expiration, date created, etc?
-
-    @Column(nullable = false)
-    val owner: String,
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    val ownerType: OwnerType
+) : BaseEntity(
+    id = id,
+    timestamp = timestamp,
+    owner = owner,
+    ownerType = ownerType
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is KeypairEntity) return false
 
+        if (_id != other._id) return false
         if (id != other.id) return false
         if (timestamp != other.timestamp) return false
         if (!publicKey.contentEquals(other.publicKey)) return false
         if (!privateKey.contentEquals(other.privateKey)) return false
         if (owner != other.owner) return false
         if (ownerType != other.ownerType) return false
+        if (_version != other._version) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
+        var result = _id?.hashCode() ?: 0
+        result = 31 * result + id.hashCode()
         result = 31 * result + timestamp.hashCode()
         result = 31 * result + publicKey.contentHashCode()
         result = 31 * result + privateKey.contentHashCode()
         result = 31 * result + owner.hashCode()
         result = 31 * result + ownerType.hashCode()
+        result = 31 * result + (_version ?: 0)
         return result
     }
 

--- a/backend/src/main/kotlin/com/etchedjournal/etched/repository/EntryRepository.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/repository/EntryRepository.kt
@@ -2,10 +2,11 @@ package com.etchedjournal.etched.repository
 
 import com.etchedjournal.etched.models.entity.EntryEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
 
-interface EntryRepository : CrudRepository<EntryEntity, UUID> {
+interface EntryRepository : CrudRepository<EntryEntity, Long> {
     fun findByOwner(owner: String): Iterable<EntryEntity>
 
-    fun findByJournal_Id(journalId: UUID): List<EntryEntity>
+    fun findById(id: String): EntryEntity?
+
+    fun findByJournal_Id(journalId: String): List<EntryEntity>
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/repository/EtchRepository.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/repository/EtchRepository.kt
@@ -2,8 +2,9 @@ package com.etchedjournal.etched.repository
 
 import com.etchedjournal.etched.models.entity.EtchEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
 
-interface EtchRepository : CrudRepository<EtchEntity, UUID> {
-    fun findByEntryId(entryId: UUID): List<EtchEntity>
+interface EtchRepository : CrudRepository<EtchEntity, Long> {
+    fun findByEntryId(entryId: String): List<EtchEntity>
+
+    fun findById(id: String): EtchEntity?
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/repository/JournalRepository.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/repository/JournalRepository.kt
@@ -2,10 +2,11 @@ package com.etchedjournal.etched.repository
 
 import com.etchedjournal.etched.models.entity.JournalEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
 
-interface JournalRepository: CrudRepository<JournalEntity, UUID> {
+interface JournalRepository: CrudRepository<JournalEntity, Long> {
     fun findByOwner(owner: String): Iterable<JournalEntity>
 
-    fun existsByIdAndOwner(id: UUID, owner: String): Boolean
+    fun findById(id: String): JournalEntity?
+
+    fun existsByIdAndOwner(id: String, owner: String): Boolean
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/repository/KeypairRepository.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/repository/KeypairRepository.kt
@@ -2,8 +2,9 @@ package com.etchedjournal.etched.repository
 
 import com.etchedjournal.etched.models.entity.KeypairEntity
 import org.springframework.data.repository.CrudRepository
-import java.util.UUID
 
-interface KeypairRepository : CrudRepository<KeypairEntity, UUID> {
+interface KeypairRepository : CrudRepository<KeypairEntity, Long> {
     fun findByOwner(owner: String): List<KeypairEntity>
+
+    fun findById(id: String): KeypairEntity?
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/EntryService.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/EntryService.kt
@@ -1,13 +1,12 @@
 package com.etchedjournal.etched.service
 
 import com.etchedjournal.etched.models.entity.EntryEntity
-import java.util.UUID
 
 interface EntryService {
 
-    fun getEntry(entryId: UUID): EntryEntity
+    fun getEntry(entryId: String): EntryEntity
 
-    fun getEntries(journalId: UUID): List<EntryEntity>
+    fun getEntries(journalId: String): List<EntryEntity>
 
-    fun create(journalId: UUID, content: ByteArray): EntryEntity
+    fun create(journalId: String, content: ByteArray): EntryEntity
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/EtchService.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/EtchService.kt
@@ -2,12 +2,11 @@ package com.etchedjournal.etched.service
 
 import com.etchedjournal.etched.dto.EncryptedEntityRequest
 import com.etchedjournal.etched.models.entity.EtchEntity
-import java.util.UUID
 
 interface EtchService {
-    fun getEtches(entryId: UUID): List<EtchEntity>
+    fun getEtches(entryId: String): List<EtchEntity>
 
-    fun getEtch(etchId: UUID): EtchEntity
+    fun getEtch(etchId: String): EtchEntity
 
-    fun create(entryId: UUID, etches: List<EncryptedEntityRequest>): List<EtchEntity>
+    fun create(entryId: String, etches: List<EncryptedEntityRequest>): List<EtchEntity>
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/JournalService.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/JournalService.kt
@@ -1,15 +1,14 @@
 package com.etchedjournal.etched.service
 
 import com.etchedjournal.etched.models.entity.JournalEntity
-import java.util.UUID
 
 interface JournalService {
 
-    fun getJournal(id: UUID): JournalEntity
+    fun getJournal(id: String): JournalEntity
 
     fun getJournals(): List<JournalEntity>
 
     fun create(content: ByteArray): JournalEntity
 
-    fun exists(id: UUID): Boolean
+    fun exists(id: String): Boolean
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/KeypairService.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/KeypairService.kt
@@ -1,7 +1,6 @@
 package com.etchedjournal.etched.service
 
 import com.etchedjournal.etched.models.entity.KeypairEntity
-import java.util.UUID
 
 interface KeypairService {
 
@@ -20,8 +19,8 @@ interface KeypairService {
     /**
      * Get the specified keypair
      *
-     * @param keypairId the id of the keypair
-     * @return the keypair with id [keypairId]
+     * @param id the id of the keypair
+     * @return the keypair with id [id]
      */
-    fun getKeypair(keypairId: UUID): KeypairEntity
+    fun getKeypair(id: String): KeypairEntity
 }

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/EtchServiceImpl.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/EtchServiceImpl.kt
@@ -8,39 +8,41 @@ import com.etchedjournal.etched.service.AuthService
 import com.etchedjournal.etched.service.EntryService
 import com.etchedjournal.etched.service.EtchService
 import com.etchedjournal.etched.service.exception.NotFoundException
+import com.etchedjournal.etched.utils.id.IdGenerator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Instant
-import java.util.UUID
 
 @Service
 class EtchServiceImpl(
     private val etchRepository: EtchRepository,
     private val entryService: EntryService,
-    private val authService: AuthService
+    private val authService: AuthService,
+    private val idGenerator: IdGenerator
 ) : EtchService {
 
-    override fun getEtches(entryId: UUID): List<EtchEntity> {
+    override fun getEtches(entryId: String): List<EtchEntity> {
         // Defer to entryService.getEntry() to handle 404/permissions checks of Entry
         entryService.getEntry(entryId)
         logger.info("Getting etches for Entry(id={})", entryId)
         return etchRepository.findByEntryId(entryId)
     }
 
-    override fun getEtch(etchId: UUID): EtchEntity {
+    override fun getEtch(etchId: String): EtchEntity {
         logger.info("Getting EtchEntity(id={})", etchId)
-        return etchRepository.findOne(etchId)
+        return etchRepository.findById(etchId)
             ?: throw NotFoundException("No EtchEntity with id $etchId exists.")
     }
 
-    override fun create(entryId: UUID, etches: List<EncryptedEntityRequest>): List<EtchEntity> {
+    override fun create(entryId: String, etches: List<EncryptedEntityRequest>): List<EtchEntity> {
         logger.info("Creating {} etches for entry {}", etches.size, entryId)
         val entry = entryService.getEntry(entryId)
 
         val timestamp = Instant.now()
         val newEtches = etches.map {
             EtchEntity(
+                id = idGenerator.generateId(),
                 // Give all the etches the same server side timestamp
                 // The client side schema will be responsible for ordering the etches
                 timestamp = timestamp,

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/KeypairServiceImpl.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/KeypairServiceImpl.kt
@@ -7,23 +7,29 @@ import com.etchedjournal.etched.service.AuthService
 import com.etchedjournal.etched.service.KeypairService
 import com.etchedjournal.etched.service.exception.ForbiddenException
 import com.etchedjournal.etched.service.exception.NotFoundException
+import com.etchedjournal.etched.utils.id.IdGenerator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.time.Instant
 
 @Service
 class KeypairServiceImpl(
     private val keypairRepository: KeypairRepository,
-    private val authService: AuthService
+    private val authService: AuthService,
+    private val idGenerator: IdGenerator
 ) : KeypairService {
 
     override fun createKeypair(publicKey: ByteArray, privateKey: ByteArray): KeypairEntity {
+        val id = idGenerator.generateId()
+        logger.info("creating id {}", id)
         val keypair = KeypairEntity(
+            id = id,
             publicKey = publicKey,
             privateKey = privateKey,
             owner = authService.getUserId(),
-            ownerType = OwnerType.USER
+            ownerType = OwnerType.USER,
+            timestamp = Instant.now()
         )
         logger.info("Creating keypair for {}", keypair.owner)
         val saved = keypairRepository.save(keypair)
@@ -39,23 +45,23 @@ class KeypairServiceImpl(
         return userKeypairs
     }
 
-    override fun getKeypair(keypairId: UUID): KeypairEntity {
-        logger.info("Attempting to get keypair with id {}", keypairId)
-        val keypair: KeypairEntity? = keypairRepository.findOne(keypairId)
+    override fun getKeypair(id: String): KeypairEntity {
+        logger.info("Attempting to get keypair with id {}", id)
+        val keypair: KeypairEntity? = keypairRepository.findById(id)
 
         if (keypair == null) {
-            logger.info("Unable to find keypair with id {}", keypairId)
+            logger.info("Unable to find keypair with id {}", id)
             throw NotFoundException()
         }
 
         if (keypair.owner != authService.getUserId()) {
             // An attacker is attempting to access another persons keys!!!
             logger.error("[SECURITY] {} attempted to access keypair {} which belongs to {}",
-                authService.getUserId(), keypairId, keypair.owner)
+                authService.getUserId(), id, keypair.owner)
             throw ForbiddenException()
         }
 
-        logger.info("Fetched keypair with id {}", keypairId)
+        logger.info("Fetched keypair with id {}", id)
         return keypair
     }
 

--- a/backend/src/main/kotlin/com/etchedjournal/etched/utils/id/IdGenerator.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/utils/id/IdGenerator.kt
@@ -1,0 +1,18 @@
+package com.etchedjournal.etched.utils.id
+
+import net.jcip.annotations.ThreadSafe
+
+/**
+ * Generates ids
+ *
+ * @implSpec
+ * Implementations MUST be thread safe
+ */
+@ThreadSafe
+interface IdGenerator {
+
+    /**
+     * Generates a new id
+     */
+    fun generateId(): String
+}

--- a/backend/src/main/kotlin/com/etchedjournal/etched/utils/id/IdGeneratorImpl.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/utils/id/IdGeneratorImpl.kt
@@ -1,0 +1,25 @@
+package com.etchedjournal.etched.utils.id
+
+import net.jcip.annotations.ThreadSafe
+import java.util.concurrent.ThreadLocalRandom
+
+@ThreadSafe
+class IdGeneratorImpl(private val size: Int): IdGenerator {
+
+    override fun generateId(): String {
+        val random = ThreadLocalRandom.current()
+        val chars = CharArray(size)
+        for (i in 0 until size) {
+            val charPos = random.nextInt(ALLOWED_CHARS.length)
+            chars[i] = ALLOWED_CHARS[charPos]
+        }
+        return String(chars)
+    }
+
+    companion object {
+        const val ALLOWED_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        const val ID_LENGTH = 12
+
+        val INSTANCE = IdGeneratorImpl(ID_LENGTH)
+    }
+}

--- a/backend/src/main/resources/db/migration/h2/V1_0__schema.sql
+++ b/backend/src/main/resources/db/migration/h2/V1_0__schema.sql
@@ -1,38 +1,50 @@
+CREATE SEQUENCE journals_id_sequence START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE entries_id_sequence START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE etches_id_sequence START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE key_pairs_id_sequence START WITH 1 INCREMENT BY 1;
 
 CREATE TABLE journals (
-  id          UUID          DEFAULT RANDOM_UUID() PRIMARY KEY,
+  _id         BIGINT        PRIMARY KEY,
+  id          VARCHAR(12)   UNIQUE NOT NULL,
   timestamp   TIMESTAMP     NOT NULL,
   content     BINARY        NOT NULL,
   -- TODO: Make `owner` a UUID column
   owner       VARCHAR(60)   NOT NULL,
   owner_type  VARCHAR(50)   NOT NULL,
+  _version    INT           NOT NULL,
 );
 
 CREATE TABLE entries (
-  id          UUID          DEFAULT RANDOM_UUID() PRIMARY KEY,
+  _id         BIGINT        PRIMARY KEY,
+  id          VARCHAR(12)   UNIQUE NOT NULL,
   timestamp   TIMESTAMP     NOT NULL,
   content     BINARY        NOT NULL,
   owner       VARCHAR(60)   NOT NULL,
   owner_type  VARCHAR(50)   NOT NULL,
-  journal_id  UUID          NOT NULL,
-  FOREIGN KEY (journal_id) REFERENCES journals (id),
+  journal_id  BIGINT        NOT NULL,
+  _version    INT           NOT NULL,
+  FOREIGN KEY (journal_id) REFERENCES journals (_id),
 );
 
 CREATE TABLE etches (
-  id          UUID          DEFAULT RANDOM_UUID() PRIMARY KEY,
+  _id         BIGINT        PRIMARY KEY,
+  id          VARCHAR(12)   UNIQUE NOT NULL,
   timestamp   TIMESTAMP     NOT NULL,
   content     BINARY        NOT NULL,
   owner       VARCHAR(60)   NOT NULL,
   owner_type  VARCHAR(50)   NOT NULL,
-  entry_id    UUID          NOT NULL,
-  FOREIGN KEY (entry_id) REFERENCES entries (id)
+  entry_id    BIGINT        NOT NULL,
+  _version    INT           NOT NULL,
+  FOREIGN KEY (entry_id) REFERENCES entries (_id)
 );
 
 CREATE TABLE keypairs (
-  id          UUID          DEFAULT RANDOM_UUID() PRIMARY KEY,
+  _id         BIGINT        PRIMARY KEY,
+  id          VARCHAR(12)   UNIQUE NOT NULL,
   timestamp   TIMESTAMP     NOT NULL,
   public_key  BINARY        NOT NULL,
   private_key BINARY        NOT NULL,
   owner       VARCHAR(60)   NOT NULL,
   owner_type  VARCHAR(50)   NOT NULL,
+  _version    INT           NOT NULL,
 );

--- a/backend/src/test/kotlin/com/etchedjournal/etched/Matchers.kt
+++ b/backend/src/test/kotlin/com/etchedjournal/etched/Matchers.kt
@@ -1,12 +1,13 @@
 package com.etchedjournal.etched
 
+import com.etchedjournal.etched.utils.id.IdGeneratorImpl
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 import java.time.Duration
 import java.time.Instant
 import java.util.regex.Pattern
 
-class RegexMatcher(pattern: String): TypeSafeMatcher<String>() {
+class RegexMatcher(pattern: String) : TypeSafeMatcher<String>() {
 
     private val compiledPattern = Pattern.compile(pattern)
 
@@ -22,7 +23,7 @@ val UUID_MATCHER = RegexMatcher("[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F
 
 // Have to use the "Long?" type because of how it's treated
 // TypeSafeMatcher will fail at "expectedType.isInstance(item)" if you don't use the nullable type
-class TimestampRecentMatcher(private val recency: Duration): TypeSafeMatcher<Long?>() {
+class TimestampRecentMatcher(private val recency: Duration) : TypeSafeMatcher<Long?>() {
     override fun describeTo(description: Description?) {
     }
 
@@ -33,3 +34,15 @@ class TimestampRecentMatcher(private val recency: Duration): TypeSafeMatcher<Lon
 }
 
 val TIMESTAMP_RECENT_MATCHER = TimestampRecentMatcher(Duration.ofSeconds(5))
+
+class StringLengthMatcher(val length: Int) : TypeSafeMatcher<String?>() {
+    override fun describeTo(description: Description?) {
+    }
+
+    override fun matchesSafely(item: String?): Boolean {
+        if (item == null || item.length != length) return false
+        return true
+    }
+}
+
+val ID_LENGTH_MATCHER = StringLengthMatcher(length = IdGeneratorImpl.ID_LENGTH)

--- a/backend/src/test/kotlin/com/etchedjournal/etched/TestRepoUtils.kt
+++ b/backend/src/test/kotlin/com/etchedjournal/etched/TestRepoUtils.kt
@@ -16,6 +16,7 @@ class TestRepoUtils(
 ) {
 
     fun createJournal(
+        id: String,
         content: ByteArray,
         timestamp: Instant = Instant.EPOCH,
         owner: String = TestAuthService.TESTER_USER_ID,
@@ -23,6 +24,7 @@ class TestRepoUtils(
     ): JournalEntity {
         return journalRepo.save(
             JournalEntity(
+                id = id,
                 timestamp = timestamp,
                 content = content,
                 owner = owner,
@@ -32,6 +34,7 @@ class TestRepoUtils(
     }
 
     fun createEntry(
+        id: String,
         journal: JournalEntity,
         content: ByteArray,
         timestamp: Instant = Instant.EPOCH,
@@ -40,6 +43,7 @@ class TestRepoUtils(
     ): EntryEntity {
         return entryRepo.save(
             EntryEntity(
+                id = id,
                 timestamp = timestamp,
                 content = content,
                 owner = owner,
@@ -50,6 +54,7 @@ class TestRepoUtils(
     }
 
     fun createEtch(
+        id: String,
         entry: EntryEntity,
         content: ByteArray,
         timestamp: Instant = Instant.EPOCH,
@@ -58,6 +63,7 @@ class TestRepoUtils(
     ): EtchEntity {
         return etchRepo.save(
             EtchEntity(
+                id = id,
                 timestamp = timestamp,
                 content = content,
                 owner = owner,

--- a/backend/src/test/kotlin/com/etchedjournal/etched/controller/JournalServiceControllerTests.kt
+++ b/backend/src/test/kotlin/com/etchedjournal/etched/controller/JournalServiceControllerTests.kt
@@ -1,10 +1,10 @@
 package com.etchedjournal.etched.controller
 
+import com.etchedjournal.etched.ID_LENGTH_MATCHER
 import com.etchedjournal.etched.TIMESTAMP_RECENT_MATCHER
 import com.etchedjournal.etched.TestAuthService.Companion.TESTER_USER_ID
 import com.etchedjournal.etched.TestConfig
 import com.etchedjournal.etched.TestRepoUtils
-import com.etchedjournal.etched.UUID_MATCHER
 import com.etchedjournal.etched.repository.JournalRepository
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.hasSize
@@ -70,12 +70,12 @@ class JournalServiceControllerTests {
     @Test
     @WithMockUser(username = "tester", roles = ["user"])
     fun `GET journals - returns created journal`() {
-        val j = testRepoUtils.createJournal(content = byteArrayOf(1, 2))
+        val j = testRepoUtils.createJournal(id = "j1", content = byteArrayOf(1, 2))
 
         mockMvc.perform(get(JOURNALS_URL))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$", hasSize<Any>(1)))
-            .andExpect(jsonPath("$[0].id", `is`(j.id!!.toString())))
+            .andExpect(jsonPath("$[0].id", `is`(j.id)))
             .andExpect(jsonPath("$[0].timestamp", `is`(0)))
             .andExpect(jsonPath("$[0].content", `is`("AQI=")))
             .andExpect(jsonPath("$[0].owner", `is`(TESTER_USER_ID)))
@@ -86,12 +86,12 @@ class JournalServiceControllerTests {
     @Test
     @WithMockUser(username = "tester", roles = ["user"])
     fun `GET journal - returns created journal`() {
-        val j = testRepoUtils.createJournal(content = byteArrayOf(1, 2))
+        val j = testRepoUtils.createJournal(id = "j1", content = byteArrayOf(1, 2))
 
         mockMvc.perform(get("$JOURNALS_URL/${j.id}"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.*", hasSize<Any>(5)))
-            .andExpect(jsonPath("$.id", `is`(j.id!!.toString())))
+            .andExpect(jsonPath("$.id", `is`(j.id)))
             .andExpect(jsonPath("$.timestamp", `is`(0)))
             .andExpect(jsonPath("$.content", `is`("AQI=")))
             .andExpect(jsonPath("$.owner", `is`(TESTER_USER_ID)))
@@ -110,7 +110,7 @@ class JournalServiceControllerTests {
                 .content("""{ "content": "abcd" }""")
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("\$.id").value(UUID_MATCHER))
+            .andExpect(jsonPath("\$.id").value(ID_LENGTH_MATCHER))
             .andExpect(jsonPath("\$.timestamp").value(TIMESTAMP_RECENT_MATCHER))
             .andExpect(jsonPath("\$.content", `is`("abcd")))
             .andExpect(jsonPath("\$.owner", `is`(TESTER_USER_ID)))


### PR DESCRIPTION
Fixes #49.

As part of this PR I've also enabled optimistic locking (untested). So probably more correct to say, I've added the `@Version` annotation and I'm hoping that it's enough.

Notable changes
* Added an `IdGenerator` interface which is provided to the services and allows us to mock out id generation now.
* Default `IdGeneratorImpl` generates ids that are 12 characters in length
* Publicly facing ids are 12 character long strings
* Entity classes are now extended from the same base class (TODO, this feels like a mistake that's going to cause lots of issues. Lets see if my premonition is correct!)