### PR TITLE
Fixed issue with reloading returning 404s

### DIFF
--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/RedirectController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/RedirectController.kt
@@ -1,0 +1,18 @@
+package com.etchedjournal.etched.controller
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+class RedirectController {
+    @RequestMapping("/**/{[path:[^\\.]*}")
+    fun redirect(): String {
+        // When a user refreshes https://etchedjournal.com/journals
+        // It makes a request to the backend for /journals. We don't handle that route on the
+        // backend so we just forward it to the home page. And the route is handled on the frontend.
+
+        // Forward to home page so that route is preserved.
+        // https://stackoverflow.com/a/43921334
+        return "forward:/"
+    }
+}

--- a/backend/src/test/kotlin/com/etchedjournal/etched/controller/RedirectControllerTest.kt
+++ b/backend/src/test/kotlin/com/etchedjournal/etched/controller/RedirectControllerTest.kt
@@ -1,0 +1,64 @@
+package com.etchedjournal.etched.controller
+
+import com.etchedjournal.etched.TestConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import javax.transaction.Transactional
+
+@RunWith(SpringRunner::class)
+@SpringBootTest
+@Transactional
+@ContextConfiguration(classes = [TestConfig::class])
+class RedirectControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var webAppCtx: WebApplicationContext
+
+    @Before
+    fun setup() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(webAppCtx)
+            .build()
+    }
+
+    @Test
+    fun `redirects non-api path to home page`() {
+        val paths = listOf(
+            "/journals",
+            "/login",
+            "/register",
+            "/entries"
+        )
+
+        for (path in paths) {
+            val response = mockMvc.perform(get(path))
+                .andExpect(status().isOk)
+                .andReturn()
+            assertEquals("/", response.response.forwardedUrl)
+        }
+    }
+
+    @Test
+    @WithMockUser(username = "tester", roles = ["USER"])
+    fun `does not redirect known page`() {
+        val response = mockMvc.perform(get("/api/v1/journals"))
+            .andExpect(status().isOk)
+            .andReturn()
+        assertNull(response.response.forwardedUrl)
+    }
+}


### PR DESCRIPTION
Fixes #69.

Decided to have the backend forward it to the index page. Considered using HashLocationStrategy but not sure it's worth it. Should investigate whether it affects caching. But we can leave that for later.