### PR TITLE
GH-97 Fixed entry list flashing

### DIFF
--- a/frontend-ng/src/app/etches/entry-list/entry-list-container.component.ts
+++ b/frontend-ng/src/app/etches/entry-list/entry-list-container.component.ts
@@ -53,6 +53,8 @@ export class EntryListContainerComponent implements OnInit {
     }
 
     decrypt(encryptedEntries: EntryEntity[]) {
+        this.decrypting = true;
+
         // Create a copy of the encryptedEntries
         const decrypted: EntryEntity[] = encryptedEntries.slice(0);
 

--- a/frontend-ng/src/app/etches/entry-list/entry-list/entry-list.component.html
+++ b/frontend-ng/src/app/etches/entry-list/entry-list/entry-list.component.html
@@ -1,13 +1,9 @@
-<div *ngIf="entries.length > 0">
-    <h3>Entries</h3>
-    <app-entry-list-item
-        *ngFor="let e of entries"
-        [entry]="e">
-    </app-entry-list-item>
-</div>
-<div *ngIf="entries.length == 0">
-    <p>No entries</p>
-</div>
+<h3>Entries</h3>
+<app-entry-list-item
+    *ngFor="let e of entries"
+    [entry]="e">
+</app-entry-list-item>
+<p *ngIf="entries.length === 0">No entries</p>
 <button class="button is-primary" (click)="this.createEntry()">
     <span class="icon">
         <i class="fas fa-plus"></i>


### PR DESCRIPTION
Fixes #97.

We hadn't been setting `decrypting = true` and therefore it would display the entries whilst decrypting them.