### PR TITLE
GH-149 Updating url after creating entry

### DIFF
--- a/frontend-ng/src/app/etches/editor/editor-container.component.spec.ts
+++ b/frontend-ng/src/app/etches/editor/editor-container.component.spec.ts
@@ -1,27 +1,38 @@
+import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { EntryV1 } from '../../models/entry/entry-v1';
 import { ClockService } from '../../services/clock.service';
 import { FakeClock } from '../../services/clock.service.spec';
 import { FakeEntryStore, FakeEtchStore } from '../../services/fakes.service.spec';
 import { EntryStore } from '../../stores/entry.store';
 import { EtchStore } from '../../stores/etch/etch.store';
-import { EditorContainerComponent } from './editor-container.component';
+import { TestUtils } from '../../utils/test-utils.spec';
+import { EditorContainerComponent, EntryState } from './editor-container.component';
 import { EntryEditorComponent } from './entry-editor/entry-editor.component';
 import { EntryTitleComponent } from './entry-title/entry-title.component';
 import { EtchItemComponent } from './etch-item/etch-item.component';
+import createEntryEntity = TestUtils.createEntryEntity;
+import createEtch = TestUtils.createEtch;
 
 describe('EditorContainerComponent', () => {
     let component: EditorContainerComponent;
     let fixture: ComponentFixture<EditorContainerComponent>;
-    let store: EntryStore;
+    let entryStore: FakeEntryStore;
+    let etchStore: FakeEtchStore;
     let clockService: ClockService;
+    let locationSpy: any;
+
+    const FOO_ETCH = createEtch('foobar', 123);
 
     beforeEach(async(() => {
-        store = new FakeEntryStore();
+        entryStore = new FakeEntryStore();
+        etchStore = new FakeEtchStore();
         clockService = new FakeClock(1);
+        locationSpy = jasmine.createSpyObj('Location', ['replaceState']);
 
         TestBed.configureTestingModule({
             declarations: [
@@ -31,9 +42,16 @@ describe('EditorContainerComponent', () => {
                 EtchItemComponent,
             ],
             providers: [
-                { provide: EntryStore, useValue: store },
+                { provide: EntryStore, useValue: entryStore },
                 { provide: ClockService, useValue: clockService },
-                { provide: EtchStore, useValue: new FakeEtchStore() },
+                { provide: EtchStore, useValue: etchStore },
+                { provide: Location, useValue: locationSpy },
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: { queryParamMap: convertToParamMap({ journalId: 'jid' }) },
+                    },
+                },
             ],
             imports: [ReactiveFormsModule, RouterTestingModule, HttpClientTestingModule],
         }).compileComponents();
@@ -49,5 +67,74 @@ describe('EditorContainerComponent', () => {
         expect(component.title).toEqual(new Date(1).toLocaleDateString());
     });
 
-    // TODO: Add some tests here
+    it('creates entry if not yet created', fakeAsync(() => {
+        expect(component.entry).toEqual(null);
+        expect(component.state).toEqual(EntryState.NOT_CREATED);
+
+        const createEntrySpy = spyOn(entryStore, 'createEntry');
+        createEntrySpy.and.returnValue(createEntryEntity({ id: '1' }));
+        component.title = 'entry title';
+
+        component.onNewEtch(FOO_ETCH);
+        tick();
+
+        expect(component.state).toEqual(EntryState.CREATED);
+        expect(component.entry).toEqual(createEntryEntity({ id: '1' }));
+        expect(createEntrySpy).toHaveBeenCalledTimes(1);
+        expect(createEntrySpy).toHaveBeenCalledWith('jid', createEntry('entry title', 1));
+    }));
+
+    it('after entry is created any queued etches are posted', fakeAsync(() => {
+        component.title = 'title';
+
+        spyOn(entryStore, 'createEntry').and.returnValue(createEntryEntity({ id: '1' }));
+        const addEtchesSpy = spyOn(etchStore, 'addEtches');
+
+        component.onNewEtch(FOO_ETCH);
+        tick();
+
+        expect(addEtchesSpy).toHaveBeenCalledTimes(1);
+        expect(addEtchesSpy).toHaveBeenCalledWith('1', [FOO_ETCH]);
+    }));
+
+    it('replaces url state after entry is created', fakeAsync(() => {
+        component.title = 'title';
+
+        spyOn(entryStore, 'createEntry').and.returnValue(createEntryEntity({ id: '1' }));
+        component.onNewEtch(FOO_ETCH);
+        tick();
+
+        expect(locationSpy.replaceState).toHaveBeenCalledTimes(1);
+        expect(locationSpy.replaceState).toHaveBeenCalledWith('/entries/1');
+    }));
+
+    it('updating title updates title', () => {
+        const oldEntry = createEntry('old title');
+        entryStore.entriesById.set('entry1', oldEntry);
+        const updateSpy = spyOn(entryStore, 'updateEntry');
+
+        component.entry = createEntryEntity({ id: 'entry1' });
+        component.state = EntryState.CREATED;
+
+        component.onTitleChange('new title');
+
+        expect(component.title).toEqual('new title');
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledWith('entry1', { ...oldEntry, content: 'new title' });
+    });
+
+    it('updating title does not update store if entry not created', () => {
+        for (const state of [EntryState.NOT_CREATED, EntryState.CREATING]) {
+            component.entry = null;
+            component.state = state;
+            component.title = 'old';
+
+            component.onTitleChange('new title');
+            expect(component.title).toEqual('new title');
+        }
+    });
+
+    function createEntry(content: string, created: number = 123): EntryV1 {
+        return new EntryV1({ content, created });
+    }
 });

--- a/frontend-ng/src/app/etches/editor/editor-container.component.ts
+++ b/frontend-ng/src/app/etches/editor/editor-container.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Location } from '@angular/common';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
 import { EntryV1 } from '../../models/entry/entry-v1';
 import { AbstractEtch } from '../../models/etch/abstract-etch';
 import { EtchV1 } from '../../models/etch/etch-v1';
@@ -10,61 +10,52 @@ import { EntryStore } from '../../stores/entry.store';
 import { EtchStore } from '../../stores/etch/etch.store';
 import { maybeUpdateTitle } from './editor-container-utils';
 
-const ENTRY_NOT_CREATED = 'NOT_CREATED';
-const ENTRY_CREATING = 'ENTRY_CREATING';
-const ENTRY_CREATED = 'ENTRY_CREATED';
+export enum EntryState {
+    NOT_CREATED,
+    CREATING,
+    CREATED,
+}
 
 @Component({
     selector: 'app-editor-container',
     templateUrl: './editor-container.component.html',
     styleUrls: ['./editor-container.component.css'],
 })
-export class EditorContainerComponent implements OnInit, OnDestroy {
+export class EditorContainerComponent {
     /** Current title */
     public title: string;
-
-    /** the current state of the entry */
-    private entryCreationState: string;
-
-    private journalId: string;
-
+    private readonly journalId: string;
+    public entry: EntryEntity | null;
     // Have to keep our own queue until the entry is created
     private queuedEtches: AbstractEtch[] = [];
-
-    private entrySubject: BehaviorSubject<EntryEntity>;
+    /** the current state of the entry */
+    public state: EntryState;
 
     constructor(
         private entryStore: EntryStore,
         private etchStore: EtchStore,
         private clockService: ClockService,
+        private location: Location,
         route: ActivatedRoute
     ) {
         this.title = clockService.now().toLocaleDateString();
-        this.entrySubject = new BehaviorSubject(null);
+        this.entry = null;
         // TODO: Should we subscribe to journalId param changes or is snapshot okay?
         this.journalId = route.snapshot.queryParamMap.get('journalId');
         if (this.journalId === null) {
+            // TODO: 404 or something
             console.error('No journal id');
         }
+        this.state = EntryState.NOT_CREATED;
     }
 
-    public ngOnInit() {
-        this.entryCreationState = ENTRY_NOT_CREATED;
-
-        this.entrySubject.subscribe(entry => {
-            if (entry !== null) {
-                console.info('posting queued etches');
-                const copy = this.queuedEtches.slice();
-                this.queuedEtches = [];
-                copy.forEach(etch => {
-                    this.queueEtch(etch);
-                });
-            }
-        });
-    }
-
-    public ngOnDestroy() {
-        this.entrySubject.unsubscribe();
+    public onNewEtch(etch: EtchV1) {
+        if (this.entry === null) {
+            this.queuedEtches.push(etch);
+            this.createEntry();
+        } else {
+            this.queueEtches([etch]);
+        }
     }
 
     /**
@@ -72,46 +63,52 @@ export class EditorContainerComponent implements OnInit, OnDestroy {
      */
     private async createEntry() {
         console.info('Attempting to create entry');
-        if (this.entryCreationState !== ENTRY_NOT_CREATED) {
+        if (this.state !== EntryState.NOT_CREATED) {
             // The entry has already been created, don't need to do anything here
             console.info('entry has already been created or is creating');
             return;
         }
-        this.entryCreationState = ENTRY_CREATING;
+        this.state = EntryState.CREATING;
         console.info('Creating entry');
         const entryV1: EntryV1 = new EntryV1({
             content: this.title,
             created: this.clockService.nowMillis(),
         });
-        const entry = await this.entryStore.createEntry(this.journalId, entryV1);
-        console.log(`Created entry with id ${entry.id}`);
-        this.entryCreationState = ENTRY_CREATED;
-        this.entrySubject.next(entry);
+        this.entry = await this.entryStore.createEntry(this.journalId, entryV1);
+
+        // Have to replace state instead of adding.
+        // This editor is called by visiting `/entries/new`
+        // When the Etch is created we want to replace the URL instead of pushing a new one to
+        // the state. If the user navigates back they should go back to the entry list. If we
+        // added a state it may seem confusing if they navigate backwards. Consider,
+        //  1. User opens entry list
+        //  2. Creates a new entry by opening /entries/new, default title is 12/05/2019
+        //  3. User creates a few etches
+        //  4. Entry is created and we add URL `/entries/A4nJpaSAAb0` to the state
+        //  5. User navigates backwards and it creates a new entry with title 12/05/2019.
+        // It may seem like their etches were lost by navigating backwards.
+        this.location.replaceState(`/entries/${this.entry.id}`);
+
+        console.log(`Created entry with id ${this.entry.id}`);
+        this.state = EntryState.CREATED;
+
+        console.info('posting queued etches');
+        const copy = this.queuedEtches.slice();
+        this.queuedEtches = [];
+        this.queueEtches(copy);
     }
 
-    public onNewEtch(etch: EtchV1) {
-        this.queuedEtches.push(etch);
-
-        const entry = this.entrySubject.getValue();
-        if (entry === null) {
-            this.createEntry();
-        } else {
-            this.queueEtch(etch);
-        }
-    }
-
-    private queueEtch(etch: AbstractEtch) {
-        const entry = this.entrySubject.getValue();
-        this.etchStore.addEtches(entry.id, [etch]);
+    private queueEtches(etches: AbstractEtch[]) {
+        this.etchStore.addEtches(this.entry.id, etches);
     }
 
     public onTitleChange(title: string) {
+        this.title = title;
         // Only rename if the updated text is different
-        if (this.entryCreationState !== ENTRY_CREATED) {
+        if (this.state !== EntryState.CREATED) {
             console.info('Skipping title update because entry is not created');
             return;
         }
-        const entity = this.entrySubject.getValue();
-        maybeUpdateTitle(this.entryStore, entity.id, title);
+        maybeUpdateTitle(this.entryStore, this.entry.id, title);
     }
 }


### PR DESCRIPTION
Fixes #149.

Something interesting about this change.

> Have to replace state instead of adding.
> This editor is called by visiting `/entries/new`
> When the Etch is created we want to replace the URL instead of pushing a new one to
> the state. If the user navigates back they should go back to the entry list. If we
> added a state it may seem confusing if they navigate backwards. Consider,
>  1. User opens entry list
>  2. Creates a new entry by opening /entries/new, default title is 12/05/2019
>  3. User creates a few etches
>  4. Entry is created and we add URL `/entries/A4nJpaSAAb0` to the state
>  5. User navigates backwards and it creates a new entry with title 12/05/2019.
> It may seem like their etches were lost by navigating backwards.